### PR TITLE
Add bower meatadata to repository

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "jquery-observe",
+  "version": "1.0.0",
+  "dependencies": {
+    "jquery": "~1.7 || ~2"
+  },
+  "main": "jquery-observer.js",
+  "homepage": "https://github.com/kapetan/jquery-observe",
+  "author": "Mirza Kapetanovic <kapetan@kapetan.com>",
+  "description": "Observe DOM mutations with jQuery",
+  "keywords": [
+    "observe",
+    "observer",
+    "jquery",
+    "dom",
+    "compatibility"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "bower.json",
+    "README.md",
+    "lib",
+    "test",
+    "build.rb",
+    "index.html",
+    "index.js",
+    "**/.*"
+  ]
+}


### PR DESCRIPTION
Hey,

I'm not sure if you know of bower, but bower is for the frontend what npm is for the backend. Even if it's quite unlikely that this component is going to change, it would still be very helpful having it accessible in a general and versioned way. All required for this would be the following four, quick steps.
- [ ] merge this pull request :-)
- [ ] update the email in the bower file (optional)
- [ ] tag the latest version using 1.0.0
- [ ] register the component by using _bower register jquery-ovserve git://github.com/kapetan/jquery-observe.git_ (optionally, I can also do this if you like)

It would be really great if you could help me getting this done! Thank you very much in advance.
