### PR TITLE
use `$.each` instead of `array.forEach`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 		var result = {};
 
 		array.forEach(function(name) {
+		$.each(array, function(idx, name) {
 			var pair = fn(name);
 
 			if(pair) {


### PR DESCRIPTION
use `$.each(array, fn)` instead of `array.forEach(fn)`

This better browser compatibility.

Note: Also, the `Object.keys` and `Function.prototype.bind` may be unavailable on old browsers.